### PR TITLE
[docs] Add a design proposal template

### DIFF
--- a/design-proposals/template.md
+++ b/design-proposals/template.md
@@ -1,0 +1,102 @@
+# Your proposal title
+
+- **Title:** `Your full title`
+- **Author(s):** `@your-github-handle, @coauthor`
+- **Date:** `YYYY-MM-DD`
+- **Status:** Draft | Review | Accepted | Superseded
+
+<!-- Status transitions: Draft → Review (PR opened) → Accepted (merged)
+     or Superseded (replaced by a later proposal; link it). -->
+
+## Overview
+
+<!-- One or two paragraphs. What are you proposing, and why, in plain words?
+A reader who stops here should know what you're asking for and roughly why. -->
+
+## Scope and related proposals
+
+<!-- Sibling or follow-up proposals and anything deliberately deferred.
+Link them by repo path or URL. If this proposal must land before or after
+another, say so. Omit the section if there are no related proposals. -->
+
+## Context
+
+<!-- Background a reader needs to evaluate the proposal.
+What does the system do today? Which files/components are relevant?
+Link to them by repo path; do not assume the reader has your tab open. -->
+
+### The problem
+
+<!-- Concrete pain, ideally in the user's voice.
+Scenarios that are broken or awkward today. -->
+
+## Goals
+
+<!-- What success looks like. Bullet list; each bullet should be testable. -->
+
+### Non-goals
+
+<!-- What this proposal explicitly does not do. Protects the scope from
+review-time drift. -->
+
+## Design
+
+<!-- The core of the proposal. Break into numbered or titled subsections
+as needed (data model, API, schema changes, template changes, controller
+changes, etc.). Show before/after for shapes that are changing. Include
+code blocks (YAML, gotemplate, Go) where prose would be ambiguous.
+Diagrams: Mermaid.js renders on GitHub. -->
+
+## User-facing changes
+
+<!-- What admins / tenants / operators will see: CLI, dashboard, CRD shape,
+docs entry point. If there is no user-facing change, say so. -->
+
+## Upgrade and rollback compatibility
+
+<!-- Will existing clusters, manifests, or APIs keep working?
+Is a migration required? Automatic or manual?
+What's the rollback story if the feature is reverted?
+If the change is irreversible once applied, flag it here. -->
+
+## Security
+
+<!-- New trust boundaries, new tenant-supplied inputs, new RBAC surface,
+new secrets stored or transmitted. If none, say so explicitly. -->
+
+## Failure and edge cases
+
+<!-- Concrete scenarios and expected behavior, one bullet each.
+Examples:
+- Invalid input X → chart rejects; Flux surfaces the error on status.
+- Migration runs twice → idempotent; no-op on the second run. -->
+
+## Testing
+
+<!-- How this will be validated. Be specific about which layer
+(unit / integration / e2e / manual) and what is asserted. -->
+
+## Rollout
+
+<!-- Ordered releases or phases. Which release ships what.
+What gets deprecated in which release. -->
+
+## Open questions
+
+<!-- Unresolved design points you want reviewer input on.
+Close these out or fold them into the body before the proposal is accepted. -->
+
+## Alternatives considered
+
+<!-- For each alternative, one short paragraph: what it is, why it was rejected.
+Group by dimension (data model, runtime mechanism, schema approach, etc.)
+when you evaluated options along multiple axes. Prevents reviewers from
+re-litigating options you already dismissed. -->
+
+---
+
+<!--
+Inspired by KubeVirt enhancement proposals
+(https://github.com/kubevirt/enhancements) and Kubernetes Enhancement
+Proposals (KEPs).
+-->

--- a/design-proposals/template.md
+++ b/design-proposals/template.md
@@ -1,12 +1,13 @@
+<!-- Rename this file to README.md and place it in a sub-directory under design-proposals/ -->
 # Your proposal title
 
 - **Title:** `Your full title`
 - **Author(s):** `@your-github-handle, @coauthor`
 - **Date:** `YYYY-MM-DD`
-- **Status:** Draft | Review | Accepted | Superseded
+- **Status:** Draft | Review | Accepted | Rejected | Superseded
 
-<!-- Status transitions: Draft → Review (PR opened) → Accepted (merged)
-     or Superseded (replaced by a later proposal; link it). -->
+<!-- Status transitions: Draft → Review (PR opened) → Accepted (merged),
+     Rejected, or Superseded (replaced by a later proposal; link it). -->
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Adds `design-proposals/template.md` as the starting point for new
proposals. Proposed as an alternative to #3 — the repo should land one
of the two.

Compared to #3, this version:

- **Puts metadata at the top** (Title / Author(s) / Date / Status) to
  match the requirement already stated in `design-proposals/README.md`.
  Adds a `Status` line for long-lived docs (Draft / Review / Accepted /
  Superseded).
- **Consistent heading levels.** Each H2 section has a single
  responsibility; sub-sections are H3 only when they belong under the
  parent (e.g. `### Non-goals` under `## Goals`).
- **Collapses "Overview / Motivation / Users and User Stories"** into
  one `## Overview` + `## Context` pair. The three-way split in #3
  tends to produce the same paragraph written three times.
- **Moves `## Alternatives considered` to the end.** Reviewers can't
  evaluate rejected options without first seeing the chosen design.
  Matches KEP/KubeVirt convention.
- **Adds `## Scope and related proposals`.** Cross-proposal scoping
  comes up as soon as there is more than one proposal in flight (see
  #4 for a live example).
- **Adds `## Failure and edge cases`** as a first-class section rather
  than a bullet under Trade-offs. Surfaces concrete misbehaviors
  reviewers can poke at.
- **Flattens "Update/Rollback Compatibility → Security → Testing"**
  into peer sections. Security and Testing are not sub-concerns of
  rollback.
- **Adds `## Open questions`** so authors have a place to park
  unresolved points instead of scattering them through the body.
- **Trailing newline** at EOF.

#4 was drafted against this shape and fits it naturally, which was the
main prompt for proposing this variant.

## Test plan

- [ ] Render the template on GitHub and confirm section headings and
      metadata placeholders display as intended
- [ ] Scaffold a scratch proposal against the template to check the
      section order reads naturally top-down
- [ ] Compare with #3 and pick one