### PR TITLE
docs: clarify where contributions land and fix dead design-proposals link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🐛 Bug in Cozystack
+    url: https://github.com/cozystack/cozystack/issues/new/choose
+    about: Bugs live in the main cozystack repo, not here.
+  - name: ✨ Feature request
+    url: https://github.com/cozystack/cozystack/issues/new/choose
+    about: Concrete, scoped features go in the main cozystack repo.
+  - name: 📐 Design proposal / RFC
+    url: https://github.com/cozystack/community/tree/main/design-proposals
+    about: Architectural or cross-cutting changes — open a design-proposal PR (markdown) in this repo. Open a blank issue here only for governance, process, or community topics.
+  - name: 💬 Question or early idea
+    url: https://github.com/cozystack/cozystack/discussions
+    about: Usage questions and half-formed ideas — use the cozystack Discussions tab or Telegram (https://t.me/cozystack).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ This repo contains (or will contain soon):
 
 We aim to make contributing to Cozystack open, transparent, and rewarding.
 
+## Where do I file?
+
+Cozystack work is split across two repositories. This repo is for **how we decide and what we should build**; the [cozystack/cozystack](https://github.com/cozystack/cozystack) repo is for **the product itself**.
+
+| You have… | Where it goes |
+|---|---|
+| A **bug** or a **concrete, scoped feature** | [cozystack/cozystack issues](https://github.com/cozystack/cozystack/issues/new/choose) |
+| A **usage question** or an early idea | [cozystack/cozystack Discussions](https://github.com/cozystack/cozystack/discussions) |
+| A **cross-cutting / architectural change** — affects multiple components or APIs, or needs a decision before code | A [design proposal](./design-proposals/README.md) (a PR) **here** |
+| **Governance, process, or community** matters | An issue **here** |
+
 ## Community Resources
 
 -   [Cozystack website](https://cozystack.io/)
@@ -39,9 +50,7 @@ Whether you're reporting an issue, proposing a feature, joining a working group,
     to ensure a respectful and inclusive environment for all community members.
 -   If you're using Cozystack, feel free to [add yourself to the ADOPTERS.md](https://github.com/cozystack/cozystack/blob/main/ADOPTERS.md)
     — we'd love to hear from you!
--   Thinking about a big feature or architectural change?
-    Start with our [design proposal guidelines](https://github.com/cozystack/cozystack/blob/main/docs/design-proposals/README.md)
-    to ensure a structured and collaborative discussion.
+-   Thinking about a big feature or architectural change? Start with our [design proposal guidelines](./design-proposals/README.md) to ensure a structured and collaborative discussion.
 
 ## Inspiration
 


### PR DESCRIPTION
## What

The community-side mirror of the contribution-routing work in
cozystack/cozystack#2854 — so both repos tell the same story about where
bugs, features, and proposals belong.

## Changes

- `README.md`: add a "Where do I file?" table (bugs/features → cozystack; proposals + governance → here) and fix the dead design-proposal-guidelines link (`cozystack/…/docs/design-proposals/` → `./design-proposals/README.md`, a path that no longer exists in the cozystack repo).
- Add `.github/ISSUE_TEMPLATE/config.yml` routing bugs/features to cozystack and reserving this repo for proposals and governance.

## Notes

- The repo description still reads "discussions and enhancement proposals" while the Discussions tab is disabled — worth reconciling (enable Discussions here, or reword to point at the cozystack Discussions tab). Not changed in this PR.
